### PR TITLE
Travis ckan master and other testing fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 python:
     - "2.7"
 env:
-    - PGVERSION=9.1 CKANVERSION=master
-    - PGVERSION=9.1 CKANVERSION=2.5.1
+    - PGVERSION=9.1 CKAN_BRANCH=master
+    - PGVERSION=9.1 CKAN_BRANCH=release-v2.5.1
 install:
     - bash bin/travis-build.bash
     - pip install coveralls -U

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 python:
     - "2.7"
-env: PGVERSION=9.1
+env:
+    - PGVERSION=9.1 CKANVERSION=master
+    - PGVERSION=9.1 CKANVERSION=2.5.1
 install:
     - bash bin/travis-build.bash
     - pip install coveralls -U

--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,7 @@ Requirements
 
 Status: Alpha
 
-Requires the CKAN development branch, `2510-iuploader-interface <https://github.com/ckan/ckan/tree/2510-iuploader-interface>`_
-.
+Requires CKAN 2.5+
 
 
 ------------

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -10,12 +10,7 @@ sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java
 echo "Installing CKAN and its Python dependencies..."
 git clone https://github.com/ckan/ckan
 cd ckan
-if [ $CKANVERSION == '2.5.1' ]
-then
-    git checkout release-v2.5.1
-else
-    git checkout master
-fi
+git checkout $CKAN_BRANCH
 python setup.py develop
 pip install -r requirements.txt --allow-all-external
 pip install -r dev-requirements.txt --allow-all-external

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -10,7 +10,12 @@ sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java
 echo "Installing CKAN and its Python dependencies..."
 git clone https://github.com/ckan/ckan
 cd ckan
-git checkout 2510-iuploader-interface
+if [ $CKANVERSION == '2.5.1']
+then
+    git checkout release-v2.5.1
+else
+    git checkout master
+fi
 python setup.py develop
 pip install -r requirements.txt --allow-all-external
 pip install -r dev-requirements.txt --allow-all-external

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -10,7 +10,7 @@ sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java
 echo "Installing CKAN and its Python dependencies..."
 git clone https://github.com/ckan/ckan
 cd ckan
-if [ $CKANVERSION == '2.5.1']
+if [ $CKANVERSION == '2.5.1' ]
 then
     git checkout release-v2.5.1
 else

--- a/ckanext/s3filestore/tests/test_controller.py
+++ b/ckanext/s3filestore/tests/test_controller.py
@@ -27,6 +27,7 @@ class TestS3ControllerResourceDownload(helpers.FunctionalTestBase):
         return resource, demo, app
 
     @mock_s3
+    @helpers.change_config('ckan.site_url', 'http://mytest.ckan.net')
     def test_resource_show_url(self):
         '''The resource_show url is expected for uploaded resource file.'''
 
@@ -35,7 +36,7 @@ class TestS3ControllerResourceDownload(helpers.FunctionalTestBase):
         # does resource_show have the expected resource file url?
         resource_show = demo.action.resource_show(id=resource['id'])
 
-        expected_url = 'http://localhost:80/dataset/{0}/resource/{1}/download/data.csv' \
+        expected_url = 'http://mytest.ckan.net/dataset/{0}/resource/{1}/download/data.csv' \
             .format(resource['package_id'], resource['id'])
 
         assert_equal(resource_show['url'], expected_url)
@@ -60,7 +61,7 @@ class TestS3ControllerResourceDownload(helpers.FunctionalTestBase):
 
         resource, demo, app = self._upload_resource()
 
-        resource_file_url = 'http://localhost:80/dataset/{0}/resource/{1}/download' \
+        resource_file_url = '/dataset/{0}/resource/{1}/download' \
             .format(resource['package_id'], resource['id'])
 
         file_response = app.get(resource_file_url)
@@ -80,7 +81,7 @@ class TestS3ControllerResourceDownload(helpers.FunctionalTestBase):
         resource = demo.action.resource_create(package_id=dataset['id'],
                                                url='http://example')
         resource_show = demo.action.resource_show(id=resource['id'])
-        resource_file_url = 'http://localhost:80/dataset/{0}/resource/{1}/download' \
+        resource_file_url = '/dataset/{0}/resource/{1}/download' \
             .format(resource['package_id'], resource['id'])
         assert_equal(resource_show['url'], 'http://example')
 

--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -70,7 +70,7 @@ class TestS3Uploader(helpers.FunctionalTestBase):
         # requesting image redirects to s3
         app = self._get_test_app()
         # attempt redirect to linked url
-        image_file_url = 'http://localhost:80/uploads/group/{0}'.format(file_name)
+        image_file_url = '/uploads/group/{0}'.format(file_name)
         r = app.get(image_file_url, status=[302, 301])
         assert_equal(r.location, 'https://my-bucket.s3.amazonaws.com/my-path/storage/uploads/group/{0}'
                                  .format(file_name))

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,4 @@
 moto==0.4.4
 ckanapi==3.5
+# a more recent httpretty is installed with moto, but has bugs causing BadStatusLine errors (https://github.com/spulec/moto/issues/303), so install a working version
+httpretty==0.6.2 


### PR DESCRIPTION
This PR fixes a few small testing errors and issues with Travis:
- It bumps the CKAN dependency used by Travis to 2.5 (it was on a ckan feature branch which has now been merged into CKAN master).
- It fixes a test by explicitly setting the site_url so the relevant assert works both locally, and on Travis.
- There's also a fix for issue #3, ensuring httpretty is pinned to an older version stop slow tests, and BadStatusLine errors causes by newer versions.
