### PR TITLE
Allow use of AMI role for authentication in AWS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,12 +59,12 @@ Config Settings
 
 Required::
 
-    ckanext.s3filestore.aws_access_key_id = Your-AWS-Access-Key-ID
+    ckanext.s3filestore.aws_bucket_name = a-bucket-to-store-your-stuff
 
 Conditional::
 
+    ckanext.s3filestore.aws_access_key_id = Your-AWS-Access-Key-ID
     ckanext.s3filestore.aws_secret_access_key = Your-AWS-Secret-Access-Key
-    ckanext.s3filestore.aws_bucket_name = a-bucket-to-store-your-stuff
    
     Or:
     

--- a/README.rst
+++ b/README.rst
@@ -60,8 +60,15 @@ Config Settings
 Required::
 
     ckanext.s3filestore.aws_access_key_id = Your-AWS-Access-Key-ID
+
+Conditional::
+
     ckanext.s3filestore.aws_secret_access_key = Your-AWS-Secret-Access-Key
     ckanext.s3filestore.aws_bucket_name = a-bucket-to-store-your-stuff
+   
+    Or:
+    
+    ckanext.s3filestore.aws_use_ami_role = true
 
 Optional::
 

--- a/ckanext/s3filestore/commands.py
+++ b/ckanext/s3filestore/commands.py
@@ -27,7 +27,7 @@ class TestConnection(toolkit.CkanCommand):
 
     def check_config(self):
         exit = False
-        required_keys = ('ckanext.s3filestore.aws_bucket_name')
+        required_keys = ('ckanext.s3filestore.aws_bucket_name',)
         if not config.get('ckanext.s3filestore.aws_use_ami_role'):
             required_keys += ('ckanext.s3filestore.aws_access_key_id',
                          'ckanext.s3filestore.aws_secret_access_key')

--- a/ckanext/s3filestore/commands.py
+++ b/ckanext/s3filestore/commands.py
@@ -27,9 +27,11 @@ class TestConnection(toolkit.CkanCommand):
 
     def check_config(self):
         exit = False
-        for key in ('ckanext.s3filestore.aws_access_key_id',
-                    'ckanext.s3filestore.aws_secret_access_key',
-                    'ckanext.s3filestore.aws_bucket_name'):
+        required_keys = ('ckanext.s3filestore.aws_bucket_name')
+        if not config.get('ckanext.s3filestore.aws_use_ami_role'):
+            required_keys += ('ckanext.s3filestore.aws_access_key_id',
+                         'ckanext.s3filestore.aws_secret_access_key')
+        for key in required_keys:
             if not config.get(key):
                 print 'You must set the "{0}" option in your ini file'.format(
                     key)

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -22,12 +22,12 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         # Certain config options must exists for the plugin to work. Raise an
         # exception if they're missing.
         missing_config = "{0} is not configured. Please amend your .ini file."
-        config_options = (
-            'ckanext.s3filestore.aws_access_key_id',
-            'ckanext.s3filestore.aws_secret_access_key',
-            'ckanext.s3filestore.aws_bucket_name'
-        )
-        for option in config_options:
+        required_options = ('ckanext.s3filestore.aws_bucket_name')
+        if not config.get('ckanext.s3filestore.aws_use_ami_role'):
+            required_options += ('ckanext.s3filestore.aws_access_key_id',
+                              'ckanext.s3filestore.aws_secret_access_key')
+
+        for option in required_options:
             if not config.get(option, None):
                 raise RuntimeError(missing_config.format(option))
 

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -22,7 +22,7 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         # Certain config options must exists for the plugin to work. Raise an
         # exception if they're missing.
         missing_config = "{0} is not configured. Please amend your .ini file."
-        required_options = ('ckanext.s3filestore.aws_bucket_name')
+        required_options = ('ckanext.s3filestore.aws_bucket_name',)
         if not config.get('ckanext.s3filestore.aws_use_ami_role'):
             required_options += ('ckanext.s3filestore.aws_access_key_id',
                               'ckanext.s3filestore.aws_secret_access_key')

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -37,7 +37,7 @@ class BaseS3Uploader(object):
         if not config.get('ckanext.s3filestore.aws_use_ami_role'):
             p_key = config.get('ckanext.s3filestore.aws_access_key_id')
             s_key = config.get('ckanext.s3filestore.aws_secret_access_key')
-        else
+        else:
             p_key, s_key = (None, None)
 
         # make s3 connection

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -34,8 +34,11 @@ class BaseS3Uploader(object):
 
     def get_s3_bucket(self, bucket_name):
         '''Return a boto bucket, creating it if it doesn't exist.'''
-        p_key = config.get('ckanext.s3filestore.aws_access_key_id')
-        s_key = config.get('ckanext.s3filestore.aws_secret_access_key')
+        if not config.get('ckanext.s3filestore.aws_use_ami_role'):
+            p_key = config.get('ckanext.s3filestore.aws_access_key_id')
+            s_key = config.get('ckanext.s3filestore.aws_secret_access_key')
+        else
+            p_key, s_key = (None, None)
 
         # make s3 connection
         S3_conn = boto.connect_s3(p_key, s_key)


### PR DESCRIPTION
AMI roles enable access control to S3 if CKAN is running on EC2 virtual machine.

This PR enables leaving access keys out of the configuration, instead user enables use of ami role with ckanext.s3filestore.aws_use_ami_role.

This PR is built upon FuhuXia's original commit.
