### PR TITLE
Add configuration options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,9 @@ Optional::
     # The ckan storage path option must also be set correctly for the fallback to work
     ckan.storage_path = path/to/storage/directory
 
+    # To change the acl of the uploaded file. Default is public-read.
+    ckanext.s3filestore.acl = private
+
 
 ------------------------
 Development Installation

--- a/README.rst
+++ b/README.rst
@@ -59,12 +59,20 @@ Config Settings
 
 Required::
 
-    ckanext.s3filestore.aws_access_key_id = Your-Access-Key-ID
-    ckanext.s3filestore.aws_secret_access_key = Your-Secret-Access-Key
+
     ckanext.s3filestore.aws_bucket_name = a-bucket-to-store-your-stuff
     ckanext.s3filestore.host_name = host-to-S3-cloud storage 
-    ckanext.s3filestore.region_name= region-name
+    ckanext.s3filestore.region_name = region-name
     ckanext.s3filestore.signature_version = signature (s3v4)
+
+Conditional:
+
+   ckanext.s3filestore.aws_access_key_id = Your-Access-Key-ID
+   ckanext.s3filestore.aws_secret_access_key = Your-Secret-Access-Key
+
+   Or:
+
+   ckanext.s3filestore.aws_use_ami_role = true
 
 Optional::
 

--- a/ckanext/s3filestore/commands.py
+++ b/ckanext/s3filestore/commands.py
@@ -21,23 +21,26 @@ class TestConnection(toolkit.CkanCommand):
     def command(self):
         self._load_config()
         if not self.args:
-            print self.usage
+            print(self.usage)
         elif self.args[0] == 'check-config':
             self.check_config()
 
     def check_config(self):
         exit = False
-        for key in ('ckanext.s3filestore.aws_access_key_id',
-                    'ckanext.s3filestore.aws_secret_access_key',
-                    'ckanext.s3filestore.aws_bucket_name'):
+        required_keys = ('ckanext.s3filestore.aws_bucket_name',)
+        if not config.get('ckanext.s3filestore.aws_use_ami_role'):
+            required_keys += ('ckanext.s3filestore.aws_access_key_id',
+                              'ckanext.s3filestore.aws_secret_access_key')
+        for key in required_keys:
             if not config.get(key):
-                print 'You must set the "{0}" option in your ini file'.format(
+                print
+                'You must set the "{0}" option in your ini file'.format(
                     key)
                 exit = True
         if exit:
             sys.exit(1)
 
-        print 'All configuration options defined'
+        print('All configuration options defined')
         bucket_name = config.get('ckanext.s3filestore.aws_bucket_name')
         public_key = config.get('ckanext.s3filestore.aws_access_key_id')
         secret_key = config.get('ckanext.s3filestore.aws_secret_access_key')
@@ -47,12 +50,12 @@ class TestConnection(toolkit.CkanCommand):
         # Check if bucket exists
         bucket = S3_conn.lookup(bucket_name)
         if bucket is None:
-            print 'Bucket {0} does not exist, trying to create it...'.format(
-                bucket_name)
+            print('Bucket {0} does not exist, trying to create it...'.format(
+                bucket_name))
             try:
                 bucket = S3_conn.create_bucket(bucket_name)
             except boto.exception.StandardError as e:
-                print 'An error was found while creating the bucket:'
-                print str(e)
+                print('An error was found while creating the bucket:')
+                print(str(e))
                 sys.exit(1)
-        print 'Configuration OK!'
+        print('Configuration OK!')

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -22,15 +22,18 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         # Certain config options must exists for the plugin to work. Raise an
         # exception if they're missing.
         missing_config = "{0} is not configured. Please amend your .ini file."
-        config_options = (
-            'ckanext.s3filestore.aws_access_key_id',
-            'ckanext.s3filestore.aws_secret_access_key',
+
+        required_options = (
             'ckanext.s3filestore.aws_bucket_name',
             'ckanext.s3filestore.region_name',
             'ckanext.s3filestore.signature_version',
             'ckanext.s3filestore.host_name'
         )
-        for option in config_options:
+        if not config.get('ckanext.s3filestore.aws_use_ami_role'):
+            required_options += ('ckanext.s3filestore.aws_access_key_id',
+                                 'ckanext.s3filestore.aws_secret_access_key')
+
+        for option in required_options:
             if not config.get(option, None):
                 raise RuntimeError(missing_config.format(option))
 

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -40,8 +40,8 @@ class BaseS3Uploader(object):
 
     def __init__(self):
         self.bucket_name = config.get('ckanext.s3filestore.aws_bucket_name')
-        self.p_key = config.get('ckanext.s3filestore.aws_access_key_id')
-        self.s_key = config.get('ckanext.s3filestore.aws_secret_access_key')
+        self.p_key = config.get('ckanext.s3filestore.aws_access_key_id', None)
+        self.s_key = config.get('ckanext.s3filestore.aws_secret_access_key', None)
         self.region = config.get('ckanext.s3filestore.region_name')
         self.signature = config.get('ckanext.s3filestore.signature_version')
         self.host_name = config.get('ckanext.s3filestore.host_name')

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -45,6 +45,7 @@ class BaseS3Uploader(object):
         self.region = config.get('ckanext.s3filestore.region_name')
         self.signature = config.get('ckanext.s3filestore.signature_version')
         self.host_name = config.get('ckanext.s3filestore.host_name')
+        self.acl = config.get('ckanext.s3filestore.acl', 'public-read')
         self.bucket = self.get_s3_bucket(self.bucket_name)
 
     def get_directory(self, id, storage_path):
@@ -114,7 +115,7 @@ class BaseS3Uploader(object):
                               config=botocore.client.Config(signature_version=self.signature))
         try:
             s3.Object(self.bucket_name, filepath).put(
-                Body=upload_file.read(), ACL='public-read',
+                Body=upload_file.read(), ACL=self.acl,
                 ContentType=getattr(self, 'mimetype', None))
             log.info("Succesfully uploaded {0} to S3!".format(filepath))
         except Exception as e:


### PR DESCRIPTION
- `ckanext.s3filestore.aws_use_ami_role` to make access keys optional
- `ckanext.s3filestore.acl` to change the ACL applied to uploaded files.

bstutsky/ckanext-s3filestore appears to be the cleanest and most up-to-date implementation of these features as at 2019-11-29.